### PR TITLE
Update is function in domselection.js

### DIFF
--- a/admin/assets/js/mura.js
+++ b/admin/assets/js/mura.js
@@ -17601,7 +17601,11 @@ Mura.DOMSelection = Mura.Core.extend(
 		if (!this.selection.length) {
 			return false;
 		}
-		return this.selection[0].matchesSelector && this.selection[0].matchesSelector(selector);
+		if (typeof this.selection[0] !== "undefined") {
+		        return this.selection[0].matchesSelector && this.selection[0].matchesSelector(selector);
+		} else {
+		        return false;
+		}
 	},
 
 	/**


### PR DESCRIPTION
Uncaught (in promise) DOMException: Failed to execute 'webkitMatchesSelector' on 'Element': '.' is not a valid selector.
    at n.is (/core/modules/v1/core_assets/js/mura.min.js?v=7.1.389:3:50343)

Fixes issue when selector is "." or other invalid selectors.